### PR TITLE
Changing the ___FILEBASENAME___ to a new variable

### DIFF
--- a/Design Pattern/VIPER Files.xctemplate/Contract/___FILEBASENAME___Contract.swift
+++ b/Design Pattern/VIPER Files.xctemplate/Contract/___FILEBASENAME___Contract.swift
@@ -8,22 +8,22 @@
 
 import Foundation
 
-protocol ___FILEBASENAME___View: BaseView {
+protocol ___VARIABLE_ModuleName___View: BaseView {
     // TODO: Declare view methods
 }
 
-protocol ___FILEBASENAME___Presentation: class {
+protocol ___VARIABLE_ModuleName___Presentation: class {
     // TODO: Declare presentation methods
 }
 
-protocol ___FILEBASENAME___UseCase: class {
+protocol ___VARIABLE_ModuleName___UseCase: class {
     // TODO: Declare use case methods
 }
 
-protocol ___FILEBASENAME___InteractorOutput: class {
+protocol ___VARIABLE_ModuleName___InteractorOutput: class {
     // TODO: Declare interactor output methods
 }
 
-protocol ___FILEBASENAME___Wireframe: class {
+protocol ___VARIABLE_ModuleName___Wireframe: class {
     // TODO: Declare wireframe methods
 }

--- a/Design Pattern/VIPER Files.xctemplate/Interactor/___FILEBASENAME___Interactor.swift
+++ b/Design Pattern/VIPER Files.xctemplate/Interactor/___FILEBASENAME___Interactor.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-class ___FILEBASENAME___Interactor {
+class ___VARIABLE_ModuleName___Interactor {
 
     // MARK: Properties
 
-    weak var output: ___FILEBASENAME___InteractorOutput?
+    weak var output: ___VARIABLE_ModuleName___InteractorOutput?
 }
 
-extension ___FILEBASENAME___Interactor: ___FILEBASENAME___UseCase {
+extension ___VARIABLE_ModuleName___Interactor: ___VARIABLE_ModuleName___UseCase {
     // TODO: Implement use case methods
 }

--- a/Design Pattern/VIPER Files.xctemplate/Presenter/___FILEBASENAME___Presenter.swift
+++ b/Design Pattern/VIPER Files.xctemplate/Presenter/___FILEBASENAME___Presenter.swift
@@ -8,19 +8,19 @@
 
 import Foundation
 
-class ___FILEBASENAME___Presenter {
+class ___VARIABLE_ModuleName___Presenter {
 
     // MARK: Properties
 
-    weak var view: ___FILEBASENAME___View?
-    var router: ___FILEBASENAME___Wireframe?
-    var interactor: ___FILEBASENAME___UseCase?
+    weak var view: ___VARIABLE_ModuleName___View?
+    var router: ___VARIABLE_ModuleName___Wireframe?
+    var interactor: ___VARIABLE_ModuleName___UseCase?
 }
 
-extension ___FILEBASENAME___Presenter: ___FILEBASENAME___Presentation {
+extension ___VARIABLE_ModuleName___Presenter: ___VARIABLE_ModuleName___Presentation {
     // TODO: implement presentation methods
 }
 
-extension ___FILEBASENAME___Presenter: ___FILEBASENAME___InteractorOutput {
+extension ___VARIABLE_ModuleName___Presenter: ___VARIABLE_ModuleName___InteractorOutput {
     // TODO: implement interactor output methods
 }

--- a/Design Pattern/VIPER Files.xctemplate/Router/___FILEBASENAME___Router.swift
+++ b/Design Pattern/VIPER Files.xctemplate/Router/___FILEBASENAME___Router.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-class ___FILEBASENAME___Router {
+class ___VARIABLE_ModuleName___Router {
 
     // MARK: Properties
 
@@ -17,11 +17,11 @@ class ___FILEBASENAME___Router {
 
     // MARK: Static methods
 
-    static func setupModule() -> ___FILEBASENAME___ViewController {
-        let viewController = UIStoryboard.loadViewController() as ___FILEBASENAME___ViewController
-        let presenter = ___FILEBASENAME___Presenter()
-        let router = ___FILEBASENAME___Router()
-        let interactor = ___FILEBASENAME___Interactor()
+    static func setupModule() -> ___VARIABLE_ModuleName___ViewController {
+        let viewController = UIStoryboard.loadViewController() as ___VARIABLE_ModuleName___ViewController
+        let presenter = ___VARIABLE_ModuleName___Presenter()
+        let router = ___VARIABLE_ModuleName___Router()
+        let interactor = ___VARIABLE_ModuleName___Interactor()
 
         viewController.presenter =  presenter
 
@@ -37,6 +37,6 @@ class ___FILEBASENAME___Router {
     }
 }
 
-extension ___FILEBASENAME___Router: ___FILEBASENAME___Wireframe {
+extension ___VARIABLE_ModuleName___Router: ___VARIABLE_ModuleName___Wireframe {
     // TODO: Implement wireframe methods
 }

--- a/Design Pattern/VIPER Files.xctemplate/TemplateInfo.plist
+++ b/Design Pattern/VIPER Files.xctemplate/TemplateInfo.plist
@@ -1,22 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-	<dict>
-		<key>AllowedTypes</key>
-		<array>
-			<string>public.swift-source</string>
-		</array>
-		<key>DefaultCompletionName</key>
-		<string>File</string>
-		<key>Description</key>
-		<string>Create VIPER files for a module.</string>
-		<key>Kind</key>
-		<string>Xcode.IDEKit.TextSubstitutionFileTemplateKind</string>
-		<key>Platforms</key>
-		<array>
-			<string>com.apple.platform.iphoneos</string>
-		</array>
-		<key>Summary</key>
-		<string>Create VIPER files for a module.</string>
-	</dict>
+<dict>
+	<key>AllowedTypes</key>
+	<array>
+		<string>public.swift-source</string>
+	</array>
+	<key>DefaultCompletionName</key>
+	<string>File</string>
+	<key>Description</key>
+	<string>Create VIPER files for a module.</string>
+	<key>Kind</key>
+	<string>Xcode.IDEKit.TextSubstitutionFileTemplateKind</string>
+	<key>Platforms</key>
+	<array>
+		<string>com.apple.platform.iphoneos</string>
+	</array>
+	<key>Options</key>
+	<array>
+		<dict>
+			<key>Description</key>
+			<string>The name of the module to create.</string>
+			<key>Identifier</key>
+			<string>ModuleName</string>
+			<key>Name</key>
+			<string>New Module Name:</string>
+			<key>NotPersisted</key>
+			<true/>
+			<key>Required</key>
+			<true/>
+			<key>Type</key>
+			<string>text</string>
+		</dict>
+		<dict>
+			<key>Default</key>
+			<string>___VARIABLE_ModuleName:identifier___</string>
+			<key>Identifier</key>
+			<string>productName</string>
+			<key>Type</key>
+			<string>static</string>
+		</dict>
+	</array>
+	<key>Summary</key>
+	<string>Create VIPER files for a module.</string>
+</dict>
 </plist>

--- a/Design Pattern/VIPER Files.xctemplate/View/___FILEBASENAME___ViewController.swift
+++ b/Design Pattern/VIPER Files.xctemplate/View/___FILEBASENAME___ViewController.swift
@@ -9,11 +9,11 @@
 import Foundation
 import UIKit
 
-class ___FILEBASENAME___ViewController: BaseViewController, StoryboardLoadable {
+class ___VARIABLE_ModuleName___ViewController: BaseViewController, StoryboardLoadable {
 
     // MARK: Properties
 
-    var presenter: ___FILEBASENAME___Presentation?
+    var presenter: ___VARIABLE_ModuleName___Presentation?
 
     // MARK: Lifecycle
 
@@ -22,6 +22,6 @@ class ___FILEBASENAME___ViewController: BaseViewController, StoryboardLoadable {
     }
 }
 
-extension ___FILEBASENAME___ViewController: ___FILEBASENAME___View {
+extension ___VARIABLE_ModuleName___ViewController: ___VARIABLE_ModuleName___View {
     // TODO: implement view output methods
 }


### PR DESCRIPTION
On Xcode 9, if you try to create a new module the `___FILEBASENAME___` will have the full text of the file.

Exemplifying: Creating a new view controller called Search, the file should be named `SearchViewController`. Once we are using this approach to generate the new class `___FILEBASENAME___ViewController` the class will be called `SearchViewControllerViewController`.

To solve that problem I've implemented a new variable called `___VARIABLE_ModuleName___` that will receive the inputted text on the creation of the new module.  