### PR TITLE
Remove unneeded class protocol declaration

### DIFF
--- a/Design Pattern/VIPER Files.xctemplate/Contract/___FILEBASENAME___Contract.swift
+++ b/Design Pattern/VIPER Files.xctemplate/Contract/___FILEBASENAME___Contract.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol ___VARIABLE_ModuleName___View: class, BaseView {
+protocol ___VARIABLE_ModuleName___View: BaseView {
     // TODO: Declare view methods
 }
 


### PR DESCRIPTION
Swift Compiler gives a warning that the `class` keyword is redundant, because the `BaseView` protocol already uses `class`